### PR TITLE
Tratando duplicidade de chave primária

### DIFF
--- a/models/marts/adw/dim_clientes.sql
+++ b/models/marts/adw/dim_clientes.sql
@@ -1,69 +1,107 @@
-with 
-    stg_cliente as (
-        select *
-        from {{ ref('stg_sap_adw__customers') }}
+WITH 
+    stg_cliente AS (
+        SELECT *
+        FROM {{ ref('stg_sap_adw__customers') }}
     )
-
-    , stg_territorio as (
-        select *
-        from {{ ref('stg_sap_adw__salesterritory') }}
+    
+    , stg_territorio AS (
+        SELECT *
+        FROM {{ ref('stg_sap_adw__salesterritory') }}
     )
-
-    , stg_cadastro_pessoa as (
-        select *
-        from {{ ref('stg_sap_adw__person') }}
+    
+    , stg_cadastro_pessoa AS (
+        SELECT *
+        FROM {{ ref('stg_sap_adw__person') }}
     )
-
-    , stg_email as (
-        select *
-        from {{ ref('stg_sap_adw__emailaddress') }}
+    
+    , stg_email AS (
+        SELECT *
+        FROM {{ ref('stg_sap_adw__emailaddress') }}
     )
-
-    , stg_cartao_credito as (
-        select *
-        from {{ ref('stg_sap_adw__creditcard') }}
+    
+    , stg_razao_compra AS (
+        SELECT *
+        FROM {{ ref('stg_sap_adw__salesreasons') }}
     )
-
-    , stg_razao_compra as (
-        select * 
-        from {{ ref('stg_sap_adw__salesreasons') }}
+    
+    , stg_vendas AS (
+        SELECT *
+        FROM {{ ref('stg_sap_adw__salesorderheadersalesreason') }}
     )
-
-    , stg_id_razaocompras as (
-        select *
-        from {{ ref('stg_sap_adw__salesorderheadersalesreason') }}
+    
+    , stg_cartao_credito AS (
+        SELECT *
+        FROM {{ ref('stg_sap_adw__creditcard') }}
     )
-
-    , stg_vendas as (
-        select * 
-        from {{ ref('stg_sap_adw__salesorderheaders') }}
+    
+    , stg_pedidos AS (
+        SELECT * 
+        FROM {{ ref('stg_sap_adw__salesorderheaders') }}
     )
-
-
-    , transformacao as (
-       select 
-            row_number() over (order by stg_cliente.pk_cliente) as cliente_sk  -- criação de uma chave surrogat
+    
+    , stg_email_recent AS (
+    SELECT 
+        stg_email.pk_entidade
+        , stg_email.email_cliente
+        , stg_email.data_modificacao
+        , ROW_NUMBER() OVER (
+            PARTITION BY stg_email.pk_entidade 
+            ORDER BY stg_email.data_modificacao DESC
+        ) AS row_num
+    FROM stg_email
+    )
+    
+    , stg_razao_compra_unique AS (
+        SELECT 
+            stg_vendas.pk_pedido
+            , stg_vendas.pk_motivo_venda
+            , stg_razao_compra.nome_motivo_venda
+            , stg_razao_compra.tipo_motivo_venda
+            , stg_vendas.data_modificacao
+            , ROW_NUMBER() OVER (
+                PARTITION BY stg_vendas.pk_pedido 
+                ORDER BY stg_vendas.data_modificacao DESC, stg_vendas.pk_motivo_venda DESC
+            ) AS row_num
+        FROM stg_vendas
+        INNER JOIN stg_razao_compra
+            ON stg_vendas.pk_motivo_venda = stg_razao_compra.pk_motivo_venda
+    )
+    
+    , transformacao AS (
+        SELECT 
+            ROW_NUMBER() OVER (ORDER BY stg_cliente.pk_cliente) AS cliente_sk
             , stg_cliente.pk_cliente
             , stg_territorio.nome_territorio
             , stg_cadastro_pessoa.nome_entidade
-            , stg_email.email_cliente
-            , stg_razao_compra.nome_motivo_venda
-            , stg_razao_compra.tipo_motivo_venda
-            -- Identifica se o cliente usou cartão de crédito
-            , case when stg_cartao_credito.pk_entidade is not null 
-                then true   
-                else false
-                end as usou_cartao_credito 
+            , stg_email_recent.email_cliente
+            , MAX(stg_razao_compra_unique.nome_motivo_venda) AS nome_motivo_venda
+            , MAX(stg_razao_compra_unique.tipo_motivo_venda) AS tipo_motivo_venda
+            , CASE 
+                WHEN stg_cartao_credito.pk_entidade IS NOT NULL THEN TRUE   
+                ELSE FALSE
+            END AS usou_cartao_credito
 
-        from stg_cliente
-        left join stg_territorio on stg_cliente.fk_territorio = stg_territorio.pk_territorio
-        left join stg_cadastro_pessoa on stg_cliente.fk_pessoa = stg_cadastro_pessoa.pk_entidade
-        left join stg_email on stg_cadastro_pessoa.pk_entidade = stg_email.pk_entidade
-        left join stg_vendas on stg_cliente.pk_cliente = stg_vendas.fk_cliente
-        left join stg_id_razaocompras on stg_vendas.pk_pedido = stg_id_razaocompras.pk_pedido
-        left join stg_razao_compra on stg_id_razaocompras.pk_motivo_venda = stg_razao_compra.pk_motivo_venda
-        left join stg_cartao_credito on stg_vendas.fk_cartao_credito = stg_cartao_credito.pk_cartao_credito
-        where stg_cadastro_pessoa.tipo_entidade = "IN"
+        FROM stg_cliente
+        LEFT JOIN stg_territorio 
+            ON stg_cliente.fk_territorio = stg_territorio.pk_territorio
+        LEFT JOIN stg_cadastro_pessoa 
+            ON stg_cliente.fk_pessoa = stg_cadastro_pessoa.pk_entidade
+        LEFT JOIN stg_email_recent 
+            ON stg_cadastro_pessoa.pk_entidade = stg_email_recent.pk_entidade AND stg_email_recent.row_num = 1
+        LEFT JOIN stg_pedidos 
+            ON stg_cliente.pk_cliente = stg_pedidos.fk_cliente
+        LEFT JOIN stg_razao_compra_unique 
+            ON stg_pedidos.pk_pedido = stg_razao_compra_unique.pk_pedido AND stg_razao_compra_unique.row_num = 1
+        LEFT JOIN stg_cartao_credito 
+            ON stg_pedidos.fk_cartao_credito = stg_cartao_credito.pk_cartao_credito
+        WHERE 
+            stg_cadastro_pessoa.tipo_entidade = "IN"
+        GROUP BY 
+            stg_cliente.pk_cliente
+            , stg_territorio.nome_territorio
+            , stg_cadastro_pessoa.nome_entidade
+            , stg_email_recent.email_cliente
+            , stg_cartao_credito.pk_entidade
     )
-select * 
-from transformacao
+SELECT * 
+FROM transformacao

--- a/models/marts/adw/dim_clientes.yml
+++ b/models/marts/adw/dim_clientes.yml
@@ -1,7 +1,7 @@
 version: 2
 
 models:
-  - name: dim_customers
+  - name: dim_clientes
     description: 'Dimensão de clientes que fornece informações detalhadas sobre os clientes, incluindo dados de contato, território e motivos de compra.'
     columns:
       - name: cliente_sk
@@ -13,6 +13,7 @@ models:
         description: 'Chave primária do cliente, vinda da tabela de origem.'
         tests:
           - not_null
+          - unique
       - name: nome_territorio
         description: 'Nome do território associado ao cliente.'
       - name: nome_entidade

--- a/models/marts/adw/dim_datas.yml
+++ b/models/marts/adw/dim_datas.yml
@@ -1,7 +1,7 @@
 version: 2
 
 models:
-  - name: dim_dates
+  - name: dim_datas
     description: 'Dimensão de datas que fornece detalhes sobre as datas de pedidos, incluindo ano, mês, dia, dia da semana, trimestre e tipo de dia.'
     columns:
       - name: date_key

--- a/models/marts/adw/dim_produtos.sql
+++ b/models/marts/adw/dim_produtos.sql
@@ -1,37 +1,38 @@
-with 
-    stg_produto as (
-        select *
-        from {{ ref('stg_sap_adw__products') }}
+WITH 
+    stg_produto AS (
+        SELECT *
+        FROM {{ ref('stg_sap_adw__products') }}
+    )
+    
+    , stg_detalhes_pedido AS (
+        SELECT *
+        FROM {{ ref('stg_sap_adw__salesorderdetails') }}
+    )
+    
+    , stg_cabecalho_pedido AS (
+        SELECT *
+        FROM {{ ref('stg_sap_adw__salesorderheaders') }}
     )
 
-    , stg_detalhes_pedido as (
-        select *
-        from {{ ref('stg_sap_adw__salesorderdetails') }}
+    , transformacao AS (
+        SELECT 
+            ROW_NUMBER() OVER (ORDER BY stg_produto.pk_produto) AS produto_sk  -- Criação de uma chave surrogate
+            , stg_produto.pk_produto AS pk_produto
+            , MAX(stg_produto.nome_produto) AS nome_produto
+            , MAX(stg_produto.produto_fabricado) AS fabricado
+            , MAX(stg_produto.produto_acabado) AS acabado
+            , MAX(stg_produto.cor_produto) AS cor
+            , MAX(stg_produto.custo_padrao_produto) AS custo_padrao
+            , MAX(stg_produto.preco_venda_sugerido) AS preco_sugerido
+            , MAX(stg_produto.dias_producao) AS dias_producao
+        FROM stg_produto 
+        LEFT JOIN stg_detalhes_pedido 
+            ON stg_produto.pk_produto = stg_detalhes_pedido.fk_produto
+        LEFT JOIN stg_cabecalho_pedido 
+            ON stg_detalhes_pedido.pk_pedido = stg_cabecalho_pedido.pk_pedido
+        GROUP BY 
+            stg_produto.pk_produto
     )
 
-    , stg_cabecalho_pedido as (
-        select *
-        from {{ ref('stg_sap_adw__salesorderheaders') }}
-    ) 
-
-
-    , transformacao as (
-        select 
-            row_number() over (order by stg_produto.pk_produto) as produto_sk --criação de uma chave surrogate  -- Criação de uma chave surrogate 
-            , stg_produto.pk_produto as pk_produto
-            , stg_produto.nome_produto as nome_produto
-            , stg_produto.produto_fabricado as fabricado
-            , stg_produto.produto_acabado as acabado
-            , stg_produto.cor_produto as cor
-            , stg_produto.custo_padrao_produto as custo_padrao
-            , stg_produto.preco_venda_sugerido as preco_sugerido
-            , stg_produto.dias_producao as dias_producao
-        from stg_produto 
-        left join stg_detalhes_pedido 
-            on stg_produto.pk_produto = stg_detalhes_pedido.fk_produto
-        left join stg_cabecalho_pedido 
-            on stg_detalhes_pedido.pk_pedido = stg_cabecalho_pedido.pk_pedido
-    )
-
-select * 
-from transformacao
+SELECT * 
+FROM transformacao

--- a/models/marts/adw/dim_produtos.yml
+++ b/models/marts/adw/dim_produtos.yml
@@ -1,7 +1,7 @@
 version: 2
 
 models:
-  - name: dim_products
+  - name: dim_produtos
     description: 'Dimensão de produtos detalhando informações sobre os produtos, incluindo características e preços sugeridos.'
     columns:
       - name: produto_sk
@@ -13,6 +13,7 @@ models:
         description: 'Chave primária do produto, vinda da tabela de origem.'
         tests:
           - not_null
+          - unique
       - name: nome_produto
         description: 'Nome do produto.'
       - name: fabricado

--- a/models/marts/adw/dim_promocoes.sql
+++ b/models/marts/adw/dim_promocoes.sql
@@ -14,22 +14,65 @@ with
         from {{ ref('stg_sap_adw__products') }}
     )
 
-    , transformacao as (
+   , stg_pedidos as (
+        select *
+        from {{ ref('stg_sap_adw__salesorderdetails') }}
+    )
+    
+    , transformacao_promocoes as (
         select 
             stg_promocao.pk_promocao
+            , stg_produto.pk_produto
             , stg_promocao.descricao_promocao
             , stg_promocao.percentual_desconto
             , stg_promocao.tipo_promocao
             , stg_promocao.categoria_promocao
             , stg_promocao.data_inicio
             , stg_promocao.data_fim
-            , stg_produto.pk_produto
             , stg_produto.nome_produto
             , DATE_DIFF(stg_promocao.data_fim, stg_promocao.data_inicio, DAY) 
             as duracao_promocao
         from stg_promocao 
-        left join stg_promocao_produto on stg_promocao.pk_promocao = stg_promocao_produto.pk_promocao
-        left join stg_produto on stg_promocao_produto.fk_produto = stg_produto.pk_produto
+        left join stg_promocao_produto 
+            on stg_promocao.pk_promocao = stg_promocao_produto.pk_promocao
+        left join stg_produto 
+            on stg_promocao_produto.fk_produto = stg_produto.pk_produto
     )
+
+    , tabela_final as (
+        select
+            stg_pedidos.pk_pedido
+            , stg_pedidos.fk_promocao
+            , stg_pedidos.quantidade_comprada
+            , stg_pedidos.preco_unitario
+            , stg_pedidos.desconto_unitario
+            , transformacao_promocoes.descricao_promocao
+            , transformacao_promocoes.percentual_desconto
+            , transformacao_promocoes.tipo_promocao
+            , transformacao_promocoes.categoria_promocao
+            , transformacao_promocoes.data_inicio
+            , transformacao_promocoes.data_fim
+            , transformacao_promocoes.nome_produto
+            , transformacao_promocoes.duracao_promocao
+        FROM stg_pedidos
+        LEFT JOIN transformacao_promocoes 
+            ON stg_pedidos.fk_promocao = transformacao_promocoes.pk_promocao
+            AND stg_pedidos.fk_produto = transformacao_promocoes.pk_produto
+        GROUP BY 
+            stg_pedidos.pk_pedido
+            , stg_pedidos.fk_promocao
+            , stg_pedidos.quantidade_comprada
+            , stg_pedidos.preco_unitario
+            , stg_pedidos.desconto_unitario
+            , transformacao_promocoes.descricao_promocao
+            , transformacao_promocoes.percentual_desconto
+            , transformacao_promocoes.tipo_promocao
+            , transformacao_promocoes.categoria_promocao
+            , transformacao_promocoes.data_inicio
+            , transformacao_promocoes.data_fim
+            , transformacao_promocoes.nome_produto
+            , transformacao_promocoes.duracao_promocao
+    )
+
 select * 
-from transformacao
+from tabela_final

--- a/models/marts/adw/dim_promocoes.yml
+++ b/models/marts/adw/dim_promocoes.yml
@@ -1,9 +1,14 @@
 version: 2
 
 models:
-  - name: dim_promotions
+  - name: dim_promocoes
     description: 'Dimensão de promoções para análises de campanhas promocionais, incluindo detalhes sobre a promoção, produtos associados e duração da oferta.'
     columns:
+      - name: pk_pedido
+        description: 'Chave primária do pedido'
+        tests:
+          - not_null
+          - unique
       - name: pk_promocao
         description: 'Chave primária da promoção, vinda da tabela de origem.'
         tests:

--- a/models/marts/adw/dim_territorios.sql
+++ b/models/marts/adw/dim_territorios.sql
@@ -19,9 +19,17 @@ with
         from {{ref('stg_sap_adw__countryregions')}}
     )
 
+    , stg_vendas as (
+        select * 
+        from {{ ref('stg_sap_adw__salesorderheaders') }}
+    )
+
     , transformacao as (
         select
-            row_number() over (order by stg_territorio.pk_territorio) as territorio_sk  -- Surrogate Key
+            concat(cast(pk_pedido as string), '-', cast(pk_cidade as string)
+                , '-' , cast(pk_territorio as string))
+                as sk_regiao
+            , stg_vendas.pk_pedido
             , stg_territorio.pk_territorio
             , stg_territorio.nome_territorio
             , stg_territorio.total_vendas_territorio
@@ -31,10 +39,13 @@ with
         from stg_territorio
         left join stg_provincia 
             on stg_territorio.pk_territorio = stg_provincia.fk_territorio
+        left join stg_vendas
+            on stg_vendas.fk_territorio = stg_territorio.pk_territorio
         left join stg_cidade 
             on stg_provincia.pk_provincia = stg_cidade.fk_provincia
         left join stg_pais 
             on stg_provincia.fk_code_regiao = stg_pais.pk_pais
+
     )
 select *
 from transformacao

--- a/models/marts/adw/dim_territorios.yml
+++ b/models/marts/adw/dim_territorios.yml
@@ -1,25 +1,27 @@
 version: 2
 
 models:
-  - name: dim_territories
-    description: 'Dimensão de territórios para análises geográficas, detalhando territórios de vendas e suas respectivas regiões, províncias e cidades.'
+  - name: dim_territorios
+    description: "Dimensão de territórios para análises geográficas, detalhando territórios de vendas e suas respectivas regiões, províncias e cidades."
     columns:
-      - name: territorio_sk
-        description: 'Chave substituta (surrogate key) que identifica de forma única cada território na tabela.'
-        tests:
-          - unique
+      - name: sk_regiao
+        description: "Chave substituta (surrogate key) que identifica de forma única cada território na tabela."
+        tests: 
           - not_null
+          - unique
+      - name: pk_pedido
+        description: "Chave primária do pedido."
       - name: pk_territorio
-        description: 'Chave primária do território, vinda da tabela de origem.'
+        description: "Chave primária do território, vinda da tabela de origem."
         tests:
           - not_null
       - name: nome_territorio
-        description: 'Nome do território de vendas.'
+        description: "Nome do território de vendas."
       - name: total_vendas_territorio
-        description: 'Total de vendas atribuídas ao território.'
+        description: "Total de vendas atribuídas ao território."
       - name: nome_pais
-        description: 'Nome do país ao qual o território pertence.'
+        description: "Nome do país ao qual o território pertence."
       - name: code_provincia
-        description: 'Código da província associada ao território.'
+        description: "Código da província associada ao território."
       - name: cidade
-        description: 'Nome da cidade dentro do território.'
+        description: "Nome da cidade dentro do território."

--- a/models/marts/adw/fct_vendas.sql
+++ b/models/marts/adw/fct_vendas.sql
@@ -20,7 +20,7 @@ with
             , vendas.pk_pedido
             , vendas.fk_cliente
             , vendas.fk_vendedor
-            , vendas.fk_territorio
+            , int_sales.sk_regiao
             , vendas.fk_cartao_credito
             , vendas_detalhes.fk_promocao
             , vendas_detalhes.pk_detalhe_pedido

--- a/models/marts/adw/fct_vendas.yml
+++ b/models/marts/adw/fct_vendas.yml
@@ -1,52 +1,71 @@
 version: 2
 
 models:
-  - name: fct_sales
-    description: 'Dimensão de pedidos de vendas, incluindo detalhes dos pedidos, status, promoções aplicadas e métricas relacionadas às vendas.'
+  - name: fct_vendas
+    description: "Dimensão de pedidos de vendas, incluindo detalhes dos pedidos, status, promoções aplicadas e métricas relacionadas às vendas."
     columns:
       - name: pk_pedido
-        description: 'Chave primária do pedido, identificando de forma única cada pedido na tabela.'
-        tests:
-          - not_null
-      - name: pk_detalhe_pedido
-        description: 'Chave primária do detalhe do pedido, identificando de forma única cada item do pedido.'
-        tests:
-          - not_null
-      - name: fk_promocao
-        description: 'Chave estrangeira referenciando a promoção aplicada ao pedido.'
-      - name: fk_produto
-        description: 'Chave estrangeira referenciando o produto incluído no pedido.'
-      - name: fk_cliente
-        description: 'Chave estrangeira referenciando o cliente que fez o pedido.'
-      - name: fk_vendedor
-        description: 'Chave estrangeira referenciando o vendedor que gerenciou o pedido.'
-      - name: fk_territorio
-        description: 'Chave estrangeira referenciando o território associado ao pedido.'
-      - name: fk_cartao_credito
-        description: 'Chave estrangeira referenciando o cartão de crédito usado no pedido, se aplicável.'
-      - name: data_pedido
-        description: 'Data em que o pedido foi realizado.'
-      - name: data_envio
-        description: 'Data em que o pedido foi enviado.'
-      - name: status_pedido
-        description: 'Código do status do pedido.'
-      - name: nome_status_pedido
-        description: 'Nome descritivo do status do pedido, baseado no código de status.'
-      - name: flag_pedido_online
-        description: 'Indica se o pedido foi realizado online (true/false).'
-      - name: quantidade_comprada
-        description: 'Quantidade de produtos comprados no pedido.'
-      - name: preco_unitario
-        description: 'Preço unitário do produto no pedido.'
-      - name: desconto_unitario
-        description: 'Desconto aplicado por unidade do produto.'
-      - name: valor_com_desconto
-        description: 'Valor do produto com o desconto aplicado.'
-      - name: tempo_frete
-        description: 'Número de dias entre a data do pedido e a data de envio.'
-      - name: sk_vendas
-        description: 'Chave substituta (surrogate key) gerada a partir de um hash MD5 que combina diversas chaves do pedido.'
+        description: "Chave primária do pedido, identificando de forma única cada pedido na tabela."
         tests:
           - not_null
           - unique
-              
+      - name: pk_detalhe_pedido
+        description: "Chave primária do detalhe do pedido, identificando de forma única cada item do pedido."
+        tests:
+          - not_null
+          - unique
+      - name: fk_promocao
+        description: "Chave estrangeira referenciando a promoção aplicada ao pedido."
+        tests:
+          - not_null
+          - unique
+      - name: fk_produto
+        description: "Chave estrangeira referenciando o produto incluído no pedido."
+        tests:
+          - not_null
+          - unique
+      - name: fk_cliente
+        description: "Chave estrangeira referenciando o cliente que fez o pedido."
+        tests:
+          - not_null
+          - unique
+      - name: fk_vendedor
+        description: "Chave estrangeira referenciando o vendedor que gerenciou o pedido."
+        tests:
+          - not_null
+          - unique
+      - name: fk_territorio
+        description: "Chave estrangeira referenciando o território associado ao pedido."
+        tests:
+          - not_null
+          - unique
+      - name: fk_cartao_credito
+        description: "Chave estrangeira referenciando o cartão de crédito usado no pedido, se aplicável."
+        tests:
+          - not_null
+          - unique
+      - name: data_pedido
+        description: "Data em que o pedido foi realizado."
+      - name: data_envio
+        description: "Data em que o pedido foi enviado."
+      - name: status_pedido
+        description: "Código do status do pedido."
+      - name: nome_status_pedido
+        description: "Nome descritivo do status do pedido, baseado no código de status."
+      - name: flag_pedido_online
+        description: "Indica se o pedido foi realizado online (true/false)."
+      - name: quantidade_comprada
+        description: "Quantidade de produtos comprados no pedido."
+      - name: preco_unitario
+        description: "Preço unitário do produto no pedido."
+      - name: desconto_unitario
+        description: "Desconto aplicado por unidade do produto."
+      - name: valor_com_desconto
+        description: "Valor do produto com o desconto aplicado."
+      - name: tempo_frete
+        description: "Número de dias entre a data do pedido e a data de envio."
+      - name: sk_vendas
+        description: "Chave substituta (surrogate key) gerada a partir de um hash MD5 que combina diversas chaves do pedido."
+        tests:
+          - not_null
+          - unique

--- a/models/marts/intermediate/int_sales.sql
+++ b/models/marts/intermediate/int_sales.sql
@@ -1,28 +1,27 @@
 with 
     vendas as (
-        select 
-            pk_pedido
-            , fk_cliente
-            , fk_vendedor
-            , fk_territorio
-            , fk_cartao_credito
-            , data_pedido
-            , data_envio
-            , status_pedido
-            , flag_pedido_online
+        select *
         from {{ ref('stg_sap_adw__salesorderheaders') }}
     )
 
     , vendas_detalhes as (
-        select 
-            pk_pedido
-            , pk_detalhe_pedido
-            , fk_promocao
-            , fk_produto
-            , quantidade_comprada 
-            , preco_unitario
-            , desconto_unitario
+        select *
         from {{ ref('stg_sap_adw__salesorderdetails') }}
+    )
+
+    ,  stg_territorio as (
+        select *
+        from {{ref('stg_sap_adw__salesterritory')}}
+    )
+
+    , stg_cidade as (
+        select *
+        from {{ref('stg_sap_adw__addresses')}}
+    )
+
+    , stg_provincia as (
+        select *
+        from {{ref('stg_sap_adw__stateprovince')}}
     )
 
     , status_pedido as (
@@ -41,9 +40,22 @@ with
         from vendas
     )
 
+    , stg_vendas_cidade as (
+        select 
+            pk_territorio
+            , pk_cidade
+        from stg_territorio
+        left join stg_provincia 
+            on stg_territorio.pk_territorio = stg_provincia.fk_territorio
+        left join stg_cidade 
+            on stg_provincia.pk_provincia = stg_cidade.fk_provincia
+    )
+
     , joined as (
         select 
             vendas.pk_pedido
+            , stg_vendas_cidade.pk_cidade
+            , stg_vendas_cidade.pk_territorio
             , vendas.fk_cliente
             , vendas.fk_vendedor
             , vendas.fk_territorio
@@ -64,6 +76,10 @@ with
             on vendas.pk_pedido = vendas_detalhes.pk_pedido
         left join status_pedido
             on vendas.pk_pedido = status_pedido.pk_pedido
+        left join stg_territorio
+            on vendas.fk_territorio = stg_territorio.pk_territorio
+        left join stg_vendas_cidade 
+            on vendas.fk_territorio = stg_vendas_cidade.pk_territorio
     )
 
     , metricas as (
@@ -85,6 +101,9 @@ with
             , preco_unitario
             , (preco_unitario * (1 - desconto_unitario)) as valor_com_desconto
             , DATE_DIFF(data_envio, data_pedido, day) as tempo_frete
+            , concat(cast(pk_pedido as string), '-', cast(pk_cidade as string)
+                , '-' , cast(pk_territorio as string))
+                as sk_regiao
             , MD5(
                 concat(
                     cast(pk_pedido as string)

--- a/models/staging/sap_adw/stg_sap_adw__addresses.sql
+++ b/models/staging/sap_adw/stg_sap_adw__addresses.sql
@@ -4,12 +4,12 @@ with
             cast(addressid as int) as pk_cidade
             , cast(stateprovinceid as int) as fk_provincia
             , cast(city as string) as cidade
+            , cast(modifieddate as timestamp) as data_modificacao
             --addressline1 -- não será necessário usar essa coluna agora
             -- addressline2 -- não será necessário usar essa coluna agora
             -- postalcode -- não será necessário usar essa coluna agora
             -- spatiallocation -- não será necessário usar essa coluna agora
             -- rowguid -- não será necessário usar essa coluna agora
-            -- modifieddate -- não será necessário usar essa coluna agora
         from {{ source('sap_adw', 'address') }}
     )
 select * 

--- a/models/staging/sap_adw/stg_sap_adw__countryregions.sql
+++ b/models/staging/sap_adw/stg_sap_adw__countryregions.sql
@@ -3,7 +3,7 @@ with
         select 
             cast (countryregioncode as string) as pk_pais
             , cast (name as string) as nome_pais
-            -- modifieddate -- não é necessário usar essa coluna neste momento. 
+            , cast(modifieddate as timestamp) as data_modificacao
         from {{ source('sap_adw', 'countryregion') }}
     )
 select * 

--- a/models/staging/sap_adw/stg_sap_adw__creditcard.sql
+++ b/models/staging/sap_adw/stg_sap_adw__creditcard.sql
@@ -3,7 +3,7 @@ with
         select 
             cast(creditcardid as int) as pk_cartao_credito
             , cast (businessentityid as int) as pk_entidade
-            -- modifieddate -- não será necessário usar para essa análise 
+            , cast(modifieddate as timestamp) as data_modificacao
         from {{ source('sap_adw', 'personcreditcard') }}
     )
 select * 

--- a/models/staging/sap_adw/stg_sap_adw__customers.sql
+++ b/models/staging/sap_adw/stg_sap_adw__customers.sql
@@ -4,9 +4,9 @@ with
         cast(customerid as int) as pk_cliente
         , cast(personid as int) as fk_pessoa
         , cast(territoryid as int) as fk_territorio
+        , cast(modifieddate as timestamp) as data_modificacao
        -- storeid - não será necessário para essa análise
        -- rowguid - não será necessário para essa análise
-       -- modifieddate - não será necessário para essa análise
         from {{ source('sap_adw', 'customer') }} 
     )
 select * 

--- a/models/staging/sap_adw/stg_sap_adw__emailaddress.sql
+++ b/models/staging/sap_adw/stg_sap_adw__emailaddress.sql
@@ -2,11 +2,12 @@ with
     rennamed as (
         select 
         cast(businessentityid as int) as pk_entidade
-        ,  cast(emailaddressid as int) as pk_email_cliente
-        ,  cast(emailaddress as string) as email_cliente
-        -- rowguid -- não será necessário para essa análise
-        -- modifieddat -- não será necessário para essa análise 
+        , cast(emailaddressid as int) as pk_email_cliente
+        , cast(emailaddress as string) as email_cliente
+        , cast(modifieddate as timestamp) as data_modificacao
+         -- rowguid -- não será necessário para essa análise
         from {{ source('dbt_brunapraca', 'personemailaddress') }}
     )
 select * 
 from rennamed
+order by pk_entidade

--- a/models/staging/sap_adw/stg_sap_adw__person.sql
+++ b/models/staging/sap_adw/stg_sap_adw__person.sql
@@ -4,6 +4,7 @@ with
         cast (businessentityid as int) as pk_entidade
         , cast (persontype as string) as tipo_entidade
         , cast (firstname as string) as nome_entidade
+        , cast(modifieddate as timestamp) as data_modificacao
         --middlename - não será necessário para essa análise
         --namestyle - não será necessário para essa análise
         --title - não será necessário para essa análise
@@ -13,7 +14,6 @@ with
         --additionalcontactinfo- não será necessário para essa análise
         --demographics- não será necessário para essa análise
         --rowguid- não será necessário para essa análise
-        --modifieddate- não será necessário para essa análise
         from {{ source('sap_adw', 'person') }} 
     )
 select * 

--- a/models/staging/sap_adw/stg_sap_adw__products.sql
+++ b/models/staging/sap_adw/stg_sap_adw__products.sql
@@ -9,6 +9,7 @@ with
             , cast(standardcost as decimal) as custo_padrao_produto
             , cast(listprice as decimal) as preco_venda_sugerido
             , cast(daystomanufacture as int) as dias_producao
+            , cast(modifieddate as timestamp) as data_modificacao
             -- productline -- este campo não será necessário para essa análise.
             -- class -- este campo não será necessário para essa análise.
             -- style -- este campo não será necessário para essa análise.
@@ -25,7 +26,6 @@ with
             -- sellenddate -- este campo não será necessário para essa análise.
             -- discontinueddate -- este campo não será necessário para essa análise.
             -- rowguid -- este campo não será necessário para essa análise.
-            -- modifieddate -- este campo não será necessário para essa análise.
         from {{ source('sap_adw', 'product') }}
     )
 select *

--- a/models/staging/sap_adw/stg_sap_adw__salesorderheaders.sql
+++ b/models/staging/sap_adw/stg_sap_adw__salesorderheaders.sql
@@ -6,11 +6,13 @@ with
             , cast(salespersonid as int) as fk_vendedor
             , cast(territoryid as int) as fk_territorio
             , cast(creditcardid as int) as fk_cartao_credito
+            , cast(billtoaddressid as int) as fk_cidade
             , cast(orderdate as timestamp) as data_pedido
             , cast(duedate as timestamp) as data_vencimento
             , cast(shipdate as timestamp) as data_envio
             , cast(status as int) as status_pedido
             , cast(onlineorderflag as boolean) as flag_pedido_online
+            , cast(modifieddate as timestamp) as data_modificacao
             -- taxamt -- não será necessário nessa análise
             -- freight -- não será necessário nessa análise
             -- totaldue -- não será necessário nessa análise
@@ -19,13 +21,11 @@ with
             -- creditcardapprovalcode-- não será necessário nessa análise
             -- shipmethodid-- não será necessário nessa análise
             -- shiptoaddressid -- não será necessário nessa análise
-            -- billtoaddressid-- não será necessário nessa análise
             -- accountnumber-- não será necessário nessa análise
             -- purchaseordernumber-- não será necessário nessa análise
             -- revisionnumbe-- não será necessário nessa análise
             -- coment -- não será necessário nessa análise
-            -- rowguid -- não será necessário nessa análise
-            -- modifieddate -- não será necessário nessa análise     
+            -- rowguid -- não será necessário nessa análise   
         from {{ source('sap_adw', 'salesorderheader') }}
     )
 select *

--- a/models/staging/sap_adw/stg_sap_adw__salesorderheadersalesreason.sql
+++ b/models/staging/sap_adw/stg_sap_adw__salesorderheadersalesreason.sql
@@ -3,7 +3,7 @@ with
         select 
         cast(salesorderid as int) as pk_pedido
         , cast(salesreasonid as int) as pk_motivo_venda
-        -- modifieddate -- não será necessário nessa análise
+        , cast(modifieddate as timestamp) as data_modificacao
         from {{ source('sap_adw', 'salesorderheadersalesreason') }}
     )
 select * 

--- a/models/staging/sap_adw/stg_sap_adw__salesperson.sql
+++ b/models/staging/sap_adw/stg_sap_adw__salesperson.sql
@@ -5,11 +5,11 @@ with
             , cast(territoryid as int) as fk_territorio
             , cast(salesquota as decimal) as cota_vendas
             , cast(salesytd as decimal) as vendas_ano_atual
+            , cast(modifieddate as timestamp) as data_modificacao
             -- bonus -- este campo não será necessário para essa análise.
             -- comissionpct -- este campo não será necessário para essa análise.
             -- saleslastyear --este campo não será necessário para essa análise.
             -- rowguid -- este campo não será necessário para essa análise.
-            -- modifieddate -- este campo não será necessário para essa análise.
         from {{ source('sap_adw', 'salesperson') }}
     )
 select *

--- a/models/staging/sap_adw/stg_sap_adw__salesreasons.sql
+++ b/models/staging/sap_adw/stg_sap_adw__salesreasons.sql
@@ -4,7 +4,7 @@ with
             cast(salesreasonid as int) as pk_motivo_venda
             , cast(name as string) as nome_motivo_venda
             , cast(reasontype as string) as tipo_motivo_venda
-            -- modifieddate -- este campo não será necessário para essa análise.
+            , cast(modifieddate as timestamp) as data_modificacao
         from {{ source('sap_adw', 'salesreason') }}
     )
     select *

--- a/models/staging/sap_adw/stg_sap_adw__salesterritory.sql
+++ b/models/staging/sap_adw/stg_sap_adw__salesterritory.sql
@@ -5,12 +5,12 @@ with
             , cast (name as string) as nome_territorio
             , cast (countryregioncode as string) as codigo_pais
             , cast (salesytd as decimal) as total_vendas_territorio
+            , cast(modifieddate as timestamp) as data_modificacao
             -- group -- não será necessário nessa análise
             -- saleslastyear -- não será necessário nessa análise
             -- costytd -- não será necessário nessa análise
             -- costlastyear -- não será necessário nessa análise
             -- rowguid -- não será necessário nessa análise
-            -- modifieddate -- não será necessário nessa análise
         from {{ source('sap_adw', 'salesterritory') }}
     )
 select * 

--- a/models/staging/sap_adw/stg_sap_adw__specialoffer.sql
+++ b/models/staging/sap_adw/stg_sap_adw__specialoffer.sql
@@ -8,10 +8,10 @@ with
             , cast(Category as string) as categoria_promocao
             , cast(StartDate as timestamp) as data_inicio
             , cast(EndDate as timestamp) as data_fim
+            , cast(modifieddate as timestamp) as data_modificacao
             --MinQty  - não será necessário para essa análise
             --MaxQty - não será necessário para essa análise
             --rowguid - não será necessário para essa análise
-            --modifiedDate - não será necessário para essa análise
         from {{ source('sap_adw', 'specialoffer') }}   
     )
 select * 

--- a/models/staging/sap_adw/stg_sap_adw__specialofferproduct.sql
+++ b/models/staging/sap_adw/stg_sap_adw__specialofferproduct.sql
@@ -3,8 +3,8 @@ with
         select 
             cast(SpecialOfferID as int) as pk_promocao
             , cast(ProductID as int) as fk_produto
+            , cast(modifieddate as timestamp) as data_modificacao
             --rowguid - não vamos usar essa coluna para essa análise
-            --modifiedDate - não vamos usar essa coluna para essa análise
         from {{ source('sap_adw', 'specialofferproduct') }}
     ) 
 select * 

--- a/models/staging/sap_adw/stg_sap_adw__stateprovince.sql
+++ b/models/staging/sap_adw/stg_sap_adw__stateprovince.sql
@@ -5,10 +5,10 @@ with
         , cast(stateprovincecode as string) as code_provincia
         , cast(countryregioncode as string) as fk_code_regiao
         , cast(territoryid as int) as fk_territorio
+        , cast(modifieddate as timestamp) as data_modificacao
         -- isonlystateprovinceflag -- não será usado para essa análise
         -- name -- não será usado para essa análise
         -- rowguid -- não será usado para essa análise
-        -- modifieddate -- não será usado para essa análise
         from {{ source('sap_adw', 'stateprovince') }}
     )
 select * 

--- a/models/staging/sap_adw/stg_sap_adw__stores.sql
+++ b/models/staging/sap_adw/stg_sap_adw__stores.sql
@@ -4,9 +4,9 @@ with
             cast(businessentityid as int) as pk_loja
             , cast(salespersonid as int) as fk_vendedor_associado
             , cast(name as string) as nome_loja
+            , cast(modifieddate as timestamp) as data_modificacao
             -- demographics -- este campo não será necessário para essa análise.
             -- rowguid -- este campo não será necessário para essa análise.
-            -- modifieddate -- este campo não será necessário para essa análise.
         from {{ source('sap_adw', 'store') }}
     )
 select *


### PR DESCRIPTION
**1. Ajustes nas Tabelas Dimensões e Fato**
Descrição: Foram realizados ajustes em todas as tabelas dimensões e na tabela fato para garantir que a chave primária de cada tabela seja única. Essas mudanças foram essenciais para manter a integridade dos dados e evitar duplicidades ou inconsistências durante a análise.
**2. Alteração na Tabela dim_territorio**
Descrição: Na tabela dim_territorio, foi necessário criar uma chave surrogate para substituir a chave primária existente. A nova chave surrogate foi adicionada à tabela fato para assegurar consistência e integridade nos relatórios e dashboards. Esta alteração foi realizada para evitar inconsistências e garantir que as relações entre as tabelas e os dados apresentados no dashboard sejam precisos e confiáveis.